### PR TITLE
feat: added forceFree to free the resources and not delete the db

### DIFF
--- a/src/clickstream.js
+++ b/src/clickstream.js
@@ -280,4 +280,29 @@ export default class Clickstream {
       )
     }
   }
+
+  /**
+   * frees up all the resource used by the Clickstream instance asynchronously and does not delete the database.
+   *
+   * clears the timeouts and intervals used.
+   * removes all the event listeners.
+   * flushes all the existing events in the system.
+   *
+   * It has no side effect on the working oh the SDK.
+   * calling .track() method again will re-create all the timeouts, interval and database for event tracking.
+   */
+  async forceFree() {
+    try {
+      await this.#scheduler.free()
+      logger.info(logPrefix, "scheduler resources are released")
+      logger.info(logPrefix, "force cleanup is done. db is not deleted.")
+    } catch (error) {
+      return Promise.reject(
+        new ClickstreamError(error.message, {
+          name: errorNames.CLEANUP_ERROR,
+          code: errorCodes.CLEANUP_ERROR,
+        })
+      )
+    }
+  }
 }

--- a/test/clickstream.test.js
+++ b/test/clickstream.test.js
@@ -17,5 +17,6 @@ describe("clickstream", () => {
     expect(clckstrm.pause).toBeDefined()
     expect(clckstrm.resume).toBeDefined()
     expect(clckstrm.free).toBeDefined()
+    expect(clckstrm.forceFree).toBeDefined()
   })
 })


### PR DESCRIPTION
- Adds a new function called `forceFree`
- Same implementation as `free` function but does not delete the indexDB